### PR TITLE
FIX: titles on notebook page

### DIFF
--- a/website/notebooks.html
+++ b/website/notebooks.html
@@ -31,11 +31,8 @@
                 <div class="table-wrapper">
                     <table class="alt" style="width:50%;">
                         <tbody>
-                            <tr>
-                                <td>Python</td>
-			    </tr>
-			    <tr>
-                                <td><a href="https://github.com/QuantEcon/book-networks-public/tree/main/ipynb/">Files on GitHub</a></td>
+			                <tr>
+                                <td><a href="https://github.com/QuantEcon/book-networks-public/tree/main/ipynb/">Download notebooks</a></td>
                             </tr>
                         </tbody>
                     </table>


### PR DESCRIPTION
Addresses @jstac comments

> On https://networks.quantecon.org/notebooks.html, I'm not sure the heading "Python" is appropriate, since some notebooks contain Julia.

> Maybe the link "Files on GitHub" should be just "Notebooks", since there's also a link below that says "GitHub".

Thanks @jstac 