### PR TITLE
ENH: add CUP and Amazon links

### DIFF
--- a/website/assets/citation.bib
+++ b/website/assets/citation.bib
@@ -1,0 +1,9 @@
+@book{Sargent_Stachurski_2024, 
+    place={Cambridge}, 
+    series={Structural Analysis in the Social Sciences}, 
+    title={Economic Networks: Theory and Computation}, 
+    publisher={Cambridge University Press}, 
+    author={Sargent, Thomas J. and Stachurski, John}, 
+    year={2024}, 
+    collection={Structural Analysis in the Social Sciences}
+}

--- a/website/index.html
+++ b/website/index.html
@@ -31,6 +31,9 @@
 							<p>Download the textbook <a href="https://github.com/QuantEcon/book-networks-public/blob/main/pdf/networks.pdf" download>here</a>
 							<br><a href="https://github.com/QuantEcon/book-networks-public/blob/main/pdf/networks_chinese.pdf" download>你可以点击 这里 下载电子版教材</a>
 							</p>
+							<p>
+							<p><a href="https://github.com/QuantEcon/book-networks-public/blob/main/assets/citation.bib" download>Bibtex Citation</a>
+							</p>
 							<ul class="actions">
 								<li><a href="#first" class="arrow scrolly"><span class="label">Next</span></a></li>
 							</ul>

--- a/website/index.html
+++ b/website/index.html
@@ -24,6 +24,10 @@
 							<h1>Economic Networks</h1>
 							<h2>Theory and Computation</h2>
 							<p><a href="http://www.tomsargent.com">Thomas J. Sargent</a> and <a href="http://johnstachurski.net">John Stachurski</a></p>
+							<p>
+							<a href="https://www.cambridge.org/core/books/economic-networks/2684D7986C7E48A82A762DFEEEA49B46">Cambridge University Press</a>
+							<br><a href="https://www.amazon.com/Economic-Networks-Theory-Computation-53/dp/1009456369/">Amazon</a>
+							</p>
 							<p>Download the textbook <a href="https://github.com/QuantEcon/book-networks-public/blob/main/pdf/networks.pdf" download>here</a>
 							<br><a href="https://github.com/QuantEcon/book-networks-public/blob/main/pdf/networks_chinese.pdf" download>你可以点击 这里 下载电子版教材</a>
 							</p>


### PR DESCRIPTION
This PR fixes #65 

1. adds links to the CUP and Amazon pages for the textbook. 
2. adds a downloadable citation (bibtex) 


<img width="1397" alt="Screenshot 2024-09-12 at 9 21 33 AM" src="https://github.com/user-attachments/assets/e00cb0e6-cc94-46be-a078-76b1ec194cb1">

