### PR TITLE
MAINT: download links rather than github hosted links for PDFS

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -28,8 +28,8 @@
 							<a href="https://www.cambridge.org/core/books/economic-networks/2684D7986C7E48A82A762DFEEEA49B46">Cambridge University Press</a>
 							<br><a href="https://www.amazon.com/Economic-Networks-Theory-Computation-53/dp/1009456369/">Amazon</a>
 							</p>
-							<p>Download the textbook <a href="https://github.com/QuantEcon/book-networks-public/blob/main/pdf/networks.pdf" download>here</a>
-							<br><a href="https://github.com/QuantEcon/book-networks-public/blob/main/pdf/networks_chinese.pdf" download>你可以点击 这里 下载电子版教材</a>
+							<p>Download the textbook <a href="https://raw.githubusercontent.com/QuantEcon/book-networks-public/main/pdf/networks.pdf" download>here</a>
+							<br><a href="https://raw.githubusercontent.com/book-networks-public/main/pdf/networks_chinese.pdf" download>你可以点击 这里 下载电子版教材</a>
 							</p>
 							<p>
 							<p><a href="https://github.com/QuantEcon/book-networks-public/blob/main/bibtex/citation.bib" download>Bibtex Citation</a>


### PR DESCRIPTION
This PR update to `raw.githubusercontent` links to enable direct downloads rather than hosted links on GitHub. 